### PR TITLE
Add ArenaTracker scraper implementation

### DIFF
--- a/ArenaTracker/calibrate.py
+++ b/ArenaTracker/calibrate.py
@@ -1,0 +1,107 @@
+import json, cv2, numpy as np
+from dataclasses import dataclass
+from typing import List
+from config import CALIB_PATH
+
+
+@dataclass
+class ROI:
+    x: int
+    y: int
+    w: int
+    h: int
+
+    def crop(self, im):
+        return im[self.y : self.y + self.h, self.x : self.x + self.w]
+
+
+@dataclass
+class Tile:
+    rect: ROI
+    title: ROI
+    dots: ROI
+
+
+def _boxes_from_edges(frame):
+    H, W = frame.shape[:2]
+    gray = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
+    gray = cv2.GaussianBlur(gray, (5, 5), 0)
+    edges = cv2.Canny(gray, 70, 170)
+    edges = cv2.dilate(edges, cv2.getStructuringElement(cv2.MORPH_RECT, (5, 5)), 1)
+    cnts, _ = cv2.findContours(edges, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
+    boxes = []
+    for c in cnts:
+        x, y, w, h = cv2.boundingRect(c)
+        area = w * h
+        ar = w / (h + 1e-9)
+        if area < 40000 or area > 300000:
+            continue
+        if 0.6 < ar < 0.9 and H * 0.12 < y < H * 0.92:
+            boxes.append((x, y, w, h))
+    # NMS
+    boxes = sorted(boxes, key=lambda r: r[2] * r[3], reverse=True)
+    kept = []
+
+    def iou(a, b):
+        ax, ay, aw, ah = a
+        bx, by, bw, bh = b
+        x1 = max(ax, bx)
+        y1 = max(ay, by)
+        x2 = min(ax + aw, bx + bw)
+        y2 = min(ay + ah, by + bh)
+        if x2 <= x1 or y2 <= y1:
+            return 0.0
+        inter = (x2 - x1) * (y2 - y1)
+        union = aw * ah + bw * bh - inter
+        return inter / union
+
+    for b in boxes:
+        if all(iou(b, k) < 0.2 for k in kept):
+            kept.append(b)
+        if len(kept) >= 12:
+            break
+    return kept
+
+
+def calibrate(frame) -> List[Tile]:
+    kept = _boxes_from_edges(frame)
+    if len(kept) < 10:
+        raise RuntimeError("Calibration failed: not enough card rectangles.")
+    kept = sorted(kept, key=lambda r: (r[1], r[0]))
+    ys = [y for _, y, _, _ in kept]
+    split = np.median(ys)
+    row1 = sorted([b for b in kept if b[1] < split], key=lambda r: r[0])[:6]
+    row2 = sorted([b for b in kept if b[1] >= split], key=lambda r: r[0])[:6]
+    boxes = row1 + row2
+    tiles = []
+    for (x, y, w, h) in boxes:
+        rect = ROI(x, y, w, h)
+        t_h = int(h * 0.16)
+        title = ROI(
+            x + int(w * 0.06),
+            y + h - t_h + int(t_h * 0.1),
+            w - int(w * 0.12),
+            t_h - int(t_h * 0.2),
+        )
+        d_h = max(12, int(h * 0.06))
+        dots = ROI(x + int(w * 0.25), y + h - t_h - d_h - 2, int(w * 0.5), d_h)
+        tiles.append(Tile(rect, title, dots))
+    return tiles
+
+
+def save_calibration(tiles: List[Tile]):
+    data = {
+        "tiles": [
+            {"rect": vars(t.rect), "title": vars(t.title), "dots": vars(t.dots)}
+            for t in tiles
+        ]
+    }
+    CALIB_PATH.write_text(json.dumps(data))
+
+
+def load_calibration() -> List[Tile]:
+    d = json.loads(CALIB_PATH.read_text())
+    toROI = lambda r: ROI(r["x"], r["y"], r["w"], r["h"])
+    return [
+        Tile(toROI(t["rect"]), toROI(t["title"]), toROI(t["dots"])) for t in d["tiles"]
+    ]

--- a/ArenaTracker/capture.py
+++ b/ArenaTracker/capture.py
@@ -1,0 +1,44 @@
+import time, numpy as np, mss, pyautogui
+from config import HOVER_DELAY_SEC
+
+
+def bring_front():
+    try:
+        import appscript
+
+        se = appscript.app('System Events')
+        apps = [
+            p
+            for p in se.application_processes.get()
+            if 'Arena' in p.name.get() or 'MTGA' in p.name.get()
+        ]
+        if apps:
+            apps[0].frontmost.set(True)
+    except Exception:
+        pass
+    w, h = pyautogui.size()
+    pyautogui.click(w // 2, h // 2)
+
+
+def mouse_safe():
+    try:
+        pyautogui.moveTo(1, 1, duration=0)
+    except Exception:
+        pass
+
+
+def screenshot() -> np.ndarray:
+    with mss.mss() as sct:
+        mon = sct.monitors[0]
+        img = np.array(sct.grab(mon))[:, :, :3]
+        return img
+
+
+def hover_screenshot(cx: int, cy: int):
+    try:
+        pyautogui.moveTo(cx, cy, duration=0)
+        time.sleep(HOVER_DELAY_SEC)
+        img = screenshot()
+    finally:
+        mouse_safe()
+    return img

--- a/ArenaTracker/config.py
+++ b/ArenaTracker/config.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+
+# All outputs in a visible folder on Desktop
+BASE_DIR = Path.home() / "Desktop" / "ArenaTracker"
+DATA_DIR = BASE_DIR / "data"
+FRAMES_DIR = DATA_DIR / "frames"
+LOG_PATH = DATA_DIR / "run.log"
+CSV_PATH = DATA_DIR / "collection.csv"
+DB_PATH = DATA_DIR / "cache.sqlite3"
+CALIB_PATH = DATA_DIR / "calibration.json"
+
+# Tunables
+FUZZY_NAME_CUTOFF = 80
+MAX_DOTS = 4
+PAGE_SETTLE_SEC = 0.40
+HOVER_DELAY_SEC = 0.25

--- a/ArenaTracker/main.py
+++ b/ArenaTracker/main.py
@@ -1,0 +1,87 @@
+import time, hashlib, cv2
+from pathlib import Path
+from typing import List, Tuple
+from config import DATA_DIR, LOG_PATH, CALIB_PATH, PAGE_SETTLE_SEC, CSV_PATH
+from capture import bring_front, screenshot, mouse_safe
+from calibrate import calibrate, save_calibration, load_calibration, Tile
+from recognize import resolve_name, count_black_dots
+from store import upsert_collection, export_csv
+from overlay import show_and_save
+
+
+def log(msg: str):
+    DATA_DIR.mkdir(parents=True, exist_ok=True)
+    line = f"[{time.strftime('%Y-%m-%d %H:%M:%S')}] {msg}"
+    print(line)
+    with open(LOG_PATH, "a") as f:
+        f.write(line + "\n")
+
+
+def page_sig(frame, tiles: List[Tile]) -> str:
+    roi = tiles[0].title.crop(frame)
+    roi = cv2.resize(roi, (64, 16), interpolation=cv2.INTER_AREA)
+    return hashlib.sha1(roi.tobytes()).hexdigest()[:16]
+
+
+def next_page():
+    import pyautogui
+
+    pyautogui.press("right")
+
+
+def run(recalibrate: bool = False, preview: bool = False, hover_ocr: bool = False):
+    bring_front()
+    time.sleep(0.5)
+    frame = screenshot()
+
+    if recalibrate or not CALIB_PATH.exists():
+        log("Calibrating (edge-based)…")
+        tiles = calibrate(frame)
+        save_calibration(tiles)
+        log(f"Saved calibration to {CALIB_PATH}")
+    else:
+        tiles = load_calibration()
+
+    seen = set()
+    first = None
+    page_idx = 0
+    looped = False
+
+    while True:
+        mouse_safe()
+        time.sleep(0.15)
+        frame = screenshot()
+        sig = page_sig(frame, tiles)
+        if first is None:
+            first = sig
+        if sig in seen and sig == first and page_idx > 0:
+            log("Detected loop to first page. Stopping.")
+            break
+        seen.add(sig)
+
+        show_and_save(frame, tiles, page_idx, window=preview)
+
+        # Process
+        for t in tiles:
+            info = resolve_name(frame, t, use_hover=hover_ocr)
+            name = info["name"] if info else ""
+            owned = count_black_dots(t.dots.crop(frame))
+            if name:
+                upsert_collection(name, owned, info)
+        export_csv()
+        log(f"Processed page {page_idx}. CSV at {CSV_PATH}")
+
+        next_page()
+        time.sleep(PAGE_SETTLE_SEC)
+        page_idx += 1
+
+
+if __name__ == "__main__":
+    import argparse
+
+    p = argparse.ArgumentParser()
+    p.add_argument("--recalibrate", action="store_true")
+    p.add_argument("--preview", action="store_true")
+    p.add_argument("--hover-ocr", action="store_true")
+    args = p.parse_args()
+    run(recalibrate=args.recalibrate, preview=args.preview, hover_ocr=args.hover_ocr)

--- a/ArenaTracker/overlay.py
+++ b/ArenaTracker/overlay.py
@@ -1,0 +1,33 @@
+import cv2
+from pathlib import Path
+from typing import List, Tuple
+from config import FRAMES_DIR
+
+
+def draw_boxes(frame, tiles, color_card=(0, 255, 0), color_title=(0, 0, 255)):
+    canvas = frame.copy()
+    for t in tiles:
+        cv2.rectangle(
+            canvas,
+            (t.rect.x, t.rect.y),
+            (t.rect.x + t.rect.w, t.rect.y + t.rect.h),
+            color_card,
+            2,
+        )
+        cv2.rectangle(
+            canvas,
+            (t.title.x, t.title.y),
+            (t.title.x + t.title.w, t.title.y + t.title.h),
+            color_title,
+            2,
+        )
+    return canvas
+
+
+def show_and_save(frame, tiles, page_idx: int, window: bool):
+    annotated = draw_boxes(frame, tiles)
+    FRAMES_DIR.mkdir(parents=True, exist_ok=True)
+    cv2.imwrite(str(FRAMES_DIR / f"page_{page_idx:04d}.png"), annotated)
+    if window:
+        cv2.imshow("Arena Scraper Preview (green=card, red=title)", annotated)
+        cv2.waitKey(1)

--- a/ArenaTracker/recognize.py
+++ b/ArenaTracker/recognize.py
@@ -1,0 +1,97 @@
+import cv2, numpy as np
+from typing import Optional, Dict
+from config import MAX_DOTS
+from store import lookup_card_by_ocr, cache_card_name, iter_art_cache, cache_art
+from capture import hover_screenshot
+
+
+def clean_text(s: str) -> str:
+    s = s.strip().replace("\n", " ")
+    for a, b in {"’": "'", "‘": "'", "“": '"', "”": '"', "—": "-", "–": "-"}.items():
+        s = s.replace(a, b)
+    return " ".join(s.split())
+
+
+def ocr_title(img) -> str:
+    import pytesseract
+
+    txt = pytesseract.image_to_string(img, config="--psm 7 -l eng")
+    return clean_text(txt)
+
+
+def count_black_dots(dot_img) -> int:
+    g = cv2.cvtColor(dot_img, cv2.COLOR_BGR2GRAY)
+    g = cv2.medianBlur(g, 3)
+    th = cv2.threshold(g, 60, 255, cv2.THRESH_BINARY_INV)[1]
+    th = cv2.morphologyEx(
+        th, cv2.MORPH_OPEN, cv2.getStructuringElement(cv2.MORPH_ELLIPSE, (3, 3)), 1
+    )
+    cnts, _ = cv2.findContours(th, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
+    owned = 0
+    for c in cnts:
+        area = cv2.contourArea(c)
+        if 10 <= area <= 300:
+            x, y, w, h = cv2.boundingRect(c)
+            r = w / float(h + 1e-9)
+            if 0.6 < r < 1.6:
+                owned += 1
+    return min(owned, MAX_DOTS)
+
+
+def ahash(img) -> str:
+    g = cv2.cvtColor(img, cv2.COLOR_BGR2GRAY)
+    g = cv2.resize(g, (8, 8), interpolation=cv2.INTER_AREA)
+    m = g.mean()
+    bits = (g > m).astype(np.uint8).flatten()
+    val = 0
+    for b in bits:
+        val = (val << 1) | int(b)
+    return f"{val:016x}"
+
+
+def hamming(a: str, b: str) -> int:
+    return bin(int(a, 16) ^ int(b, 16)).count("1")
+
+
+def art_lookup(tile_img) -> Optional[Dict]:
+    target = ahash(tile_img)
+    best = None
+    best_d = 999
+    for ah, name, sid, uri in iter_art_cache():
+        d = hamming(target, ah)
+        if d < best_d:
+            best_d = d
+            best = {"name": name, "id": sid, "uri": uri}
+    return best if best and best_d <= 5 else None
+
+
+def resolve_name(frame, tile, use_hover: bool) -> Optional[Dict]:
+    # 1) OCR on title band
+    raw = ocr_title(tile.title.crop(frame)).strip()
+    if raw:
+        from scryfall import lookup_fuzzy
+
+        info = lookup_fuzzy(raw)
+        if info:
+            cache_card_name(raw, info)
+            return info
+    # 2) Hover OCR (big preview)
+    if use_hover:
+        cx = tile.rect.x + tile.rect.w // 2
+        cy = tile.rect.y + tile.rect.h // 2
+        pop = hover_screenshot(cx, cy)
+        raw2 = ocr_title(pop).strip()
+        if raw2:
+            from scryfall import lookup_fuzzy
+
+            info2 = lookup_fuzzy(raw2)
+            if info2:
+                cache_card_name(raw2, info2)
+                return info2
+    # 3) Local art hash
+    img = tile.rect.crop(frame)
+    info3 = art_lookup(img)
+    if info3:
+        cache_art(ahash(img), info3)
+        return info3
+    return None

--- a/ArenaTracker/requirements.txt
+++ b/ArenaTracker/requirements.txt
@@ -1,0 +1,10 @@
+opencv-python
+pytesseract
+mss
+pyautogui
+numpy
+requests
+rapidfuzz
+Pillow
+appscript ; sys_platform == 'darwin'
+urllib3<2

--- a/ArenaTracker/scryfall.py
+++ b/ArenaTracker/scryfall.py
@@ -1,0 +1,20 @@
+import requests
+from typing import Optional, Dict
+
+
+def lookup_fuzzy(name: str) -> Optional[Dict]:
+    try:
+        r = requests.get(
+            "https://api.scryfall.com/cards/named", params={"fuzzy": name}, timeout=10
+        )
+        if r.status_code != 200:
+            return None
+        j = r.json()
+        return {
+            "name": j.get("name"),
+            "id": j.get("id"),
+            "uri": j.get("scryfall_uri"),
+            "set": j.get("set"),
+        }
+    except Exception:
+        return None

--- a/ArenaTracker/store.py
+++ b/ArenaTracker/store.py
@@ -1,0 +1,98 @@
+import sqlite3, time, csv
+from pathlib import Path
+from typing import Optional, Dict, Iterable, Tuple
+from config import DB_PATH, CSV_PATH
+
+
+def db():
+    DB_PATH.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(DB_PATH)
+    conn.execute("PRAGMA journal_mode=WAL;")
+    conn.execute(
+        """
+    CREATE TABLE IF NOT EXISTS card_map(
+      ocr_name TEXT PRIMARY KEY, name TEXT, scryfall_id TEXT, uri TEXT, set_code TEXT, ts INT
+    )"""
+    )
+    conn.execute(
+        """
+    CREATE TABLE IF NOT EXISTS art_map(
+      ahash TEXT PRIMARY KEY, name TEXT, scryfall_id TEXT, uri TEXT, ts INT
+    )"""
+    )
+    conn.execute(
+        """
+    CREATE TABLE IF NOT EXISTS collection(
+      name TEXT PRIMARY KEY, count INT, scryfall_id TEXT, uri TEXT, ts INT
+    )"""
+    )
+    return conn
+
+
+def cache_card_name(ocr_name: str, info: Dict):
+    conn = db()
+    conn.execute(
+        """INSERT OR REPLACE INTO card_map(ocr_name,name,scryfall_id,uri,set_code,ts)
+                    VALUES(?,?,?,?,?,?)""",
+        (
+            ocr_name,
+            info.get("name"),
+            info.get("id"),
+            info.get("uri"),
+            info.get("set"),
+            int(time.time()),
+        ),
+    )
+    conn.commit()
+
+
+def lookup_card_by_ocr(ocr_name: str) -> Optional[Dict]:
+    conn = db()
+    cur = conn.execute("SELECT name,scryfall_id,uri FROM card_map WHERE ocr_name=?", (ocr_name,))
+    r = cur.fetchone()
+    return {"name": r[0], "id": r[1], "uri": r[2]} if r else None
+
+
+def cache_art(ahash: str, info: Dict):
+    conn = db()
+    conn.execute(
+        """INSERT OR REPLACE INTO art_map(ahash,name,scryfall_id,uri,ts)
+                    VALUES(?,?,?,?,?)""",
+        (ahash, info.get("name"), info.get("id"), info.get("uri"), int(time.time())),
+    )
+    conn.commit()
+
+
+def iter_art_cache():
+    conn = db()
+    return conn.execute("SELECT ahash,name,scryfall_id,uri FROM art_map").fetchall()
+
+
+def upsert_collection(name: str, count: int, info: Optional[Dict]):
+    conn = db()
+    sid = info.get("id") if info else None
+    uri = info.get("uri") if info else None
+    conn.execute(
+        """INSERT INTO collection(name,count,scryfall_id,uri,ts)
+           VALUES(?,?,?,?,?)
+           ON CONFLICT(name) DO UPDATE SET
+             count=excluded.count,
+             scryfall_id=COALESCE(excluded.scryfall_id, collection.scryfall_id),
+             uri=COALESCE(excluded.uri, collection.uri),
+             ts=excluded.ts""",
+        (name, count, sid, uri, int(time.time())),
+    )
+    conn.commit()
+
+
+def export_csv():
+    conn = db()
+    rows = conn.execute(
+        "SELECT name,count,scryfall_id,uri FROM collection ORDER BY name COLLATE NOCASE"
+    ).fetchall()
+    CSV_PATH.parent.mkdir(parents=True, exist_ok=True)
+    with open(CSV_PATH, "w", newline="") as f:
+        w = csv.writer(f)
+        w.writerow(["Card Name", "Owned Copies", "Scryfall ID", "Scryfall URI"])
+        for r in rows:
+            w.writerow(r)

--- a/README.md
+++ b/README.md
@@ -1,1 +1,43 @@
-# MTGA-scraper
+# ArenaTracker
+
+Toolkit for extracting a player's MTG Arena collection using screen captures, OCR, and Scryfall lookups.
+
+## Project Layout
+
+```
+ArenaTracker/
+  requirements.txt
+  main.py
+  config.py
+  capture.py
+  calibrate.py
+  recognize.py
+  scryfall.py
+  store.py
+  overlay.py
+```
+
+## Installation
+
+```bash
+cd ~/Desktop
+python3 -m venv venv && source venv/bin/activate
+# macOS: install Tesseract once
+brew install tesseract
+# If you see LibreSSL warnings, pin urllib3<2
+pip install -r ArenaTracker/requirements.txt
+```
+
+## Usage
+
+```bash
+source ~/Desktop/venv/bin/activate   # if not already
+python ~/Desktop/ArenaTracker/main.py --recalibrate --preview --hover-ocr
+```
+
+* Mouse is parked to avoid the hover overlay during captures; if `--hover-ocr` is set, the script briefly hovers a tile only when needed, then parks again.
+* Green/red boxes are shown in the preview window and saved to `~/Desktop/ArenaTracker/data/frames/`.
+* Output CSV: `~/Desktop/ArenaTracker/data/collection.csv`.
+* Logs: `~/Desktop/ArenaTracker/data/run.log`.
+* Cache DB: `~/Desktop/ArenaTracker/data/cache.sqlite3`.
+* Calibration is stored and reused until you pass `--recalibrate`.


### PR DESCRIPTION
## Summary
- add ArenaTracker project with modular OCR, calibration, capture, and Scryfall lookup utilities
- configure shared paths, caching, overlay rendering, and main execution script
- document installation and usage steps in the README

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cff8b7f49c83329227c7566f2a3a9b