### PR TITLE
Prevent unintended clicks and improve obstruction handling

### DIFF
--- a/ArenaTracker/capture.py
+++ b/ArenaTracker/capture.py
@@ -16,8 +16,6 @@ def bring_front():
             apps[0].frontmost.set(True)
     except Exception:
         pass
-    w, h = pyautogui.size()
-    pyautogui.click(w // 2, h // 2)
 
 
 def mouse_safe():

--- a/ArenaTracker/main.py
+++ b/ArenaTracker/main.py
@@ -1,12 +1,17 @@
 import time, hashlib, cv2
-from pathlib import Path
-from typing import List, Tuple
+from typing import List
 from config import DATA_DIR, LOG_PATH, CALIB_PATH, PAGE_SETTLE_SEC, CSV_PATH
 from capture import bring_front, screenshot, mouse_safe
-from calibrate import calibrate, save_calibration, load_calibration, Tile
+from calibrate import (
+    calibrate,
+    save_calibration,
+    load_calibration,
+    Tile,
+    layout_matches,
+)
 from recognize import resolve_name, count_black_dots
 from store import upsert_collection, export_csv
-from overlay import show_and_save
+from overlay import show_overlay, close_overlay
 
 
 def log(msg: str):
@@ -29,6 +34,68 @@ def next_page():
     pyautogui.press("right")
 
 
+def prompt_to_resume() -> bool:
+    import tkinter as tk
+
+    root = tk.Tk()
+    root.title("Arena Tracker – Attention")
+    root.resizable(False, False)
+    root.attributes("-topmost", True)
+
+    message = (
+        "The expected 2x6 card layout is obstructed.\n"
+        "Clear the view, then press Retry to scan again or Abort to stop."
+    )
+    tk.Label(root, text=message, padx=20, pady=15, justify="center").pack()
+
+    result = {"choice": "abort"}
+
+    def choose(value: str):
+        result["choice"] = value
+        root.destroy()
+
+    button_frame = tk.Frame(root, pady=10)
+    button_frame.pack()
+    tk.Button(button_frame, text="Retry", width=12, command=lambda: choose("retry")).pack(
+        side=tk.LEFT, padx=6
+    )
+    tk.Button(
+        button_frame,
+        text="Abort",
+        width=12,
+        command=lambda: choose("abort"),
+        bg="#c0392b",
+        fg="white",
+        activebackground="#922b21",
+        activeforeground="white",
+    ).pack(side=tk.LEFT, padx=6)
+
+    root.protocol("WM_DELETE_WINDOW", lambda: choose("abort"))
+    root.mainloop()
+    return result["choice"] == "retry"
+
+
+def ensure_layout(frame, tiles: List[Tile], preview: bool):
+    if layout_matches(frame, tiles):
+        return frame
+
+    log("Card grid obstructed. Waiting for user intervention…")
+    show_overlay(frame, tiles, preview)
+
+    while True:
+        if not prompt_to_resume():
+            return None
+        bring_front()
+        time.sleep(0.5)
+        mouse_safe()
+        time.sleep(0.15)
+        frame = screenshot()
+        show_overlay(frame, tiles, preview)
+        if layout_matches(frame, tiles):
+            log("Card grid restored. Resuming.")
+            return frame
+
+
 def run(recalibrate: bool = False, preview: bool = False, hover_ocr: bool = False):
     bring_front()
     time.sleep(0.5)
@@ -45,35 +112,41 @@ def run(recalibrate: bool = False, preview: bool = False, hover_ocr: bool = Fals
     seen = set()
     first = None
     page_idx = 0
-    looped = False
+    try:
+        while True:
+            mouse_safe()
+            time.sleep(0.15)
+            frame = screenshot()
+            frame = ensure_layout(frame, tiles, preview)
+            if frame is None:
+                log("User aborted after obstruction. Stopping.")
+                break
+            sig = page_sig(frame, tiles)
+            if first is None:
+                first = sig
+            if sig in seen and sig == first and page_idx > 0:
+                log("Detected loop to first page. Stopping.")
+                break
+            seen.add(sig)
 
-    while True:
-        mouse_safe()
-        time.sleep(0.15)
-        frame = screenshot()
-        sig = page_sig(frame, tiles)
-        if first is None:
-            first = sig
-        if sig in seen and sig == first and page_idx > 0:
-            log("Detected loop to first page. Stopping.")
-            break
-        seen.add(sig)
+            show_overlay(frame, tiles, preview)
 
-        show_and_save(frame, tiles, page_idx, window=preview)
+            # Process
+            for t in tiles:
+                info = resolve_name(frame, t, use_hover=hover_ocr)
+                name = info["name"] if info else ""
+                owned = count_black_dots(t.dots.crop(frame))
+                if name:
+                    upsert_collection(name, owned, info)
+            export_csv()
+            log(f"Processed page {page_idx}. CSV at {CSV_PATH}")
 
-        # Process
-        for t in tiles:
-            info = resolve_name(frame, t, use_hover=hover_ocr)
-            name = info["name"] if info else ""
-            owned = count_black_dots(t.dots.crop(frame))
-            if name:
-                upsert_collection(name, owned, info)
-        export_csv()
-        log(f"Processed page {page_idx}. CSV at {CSV_PATH}")
-
-        next_page()
-        time.sleep(PAGE_SETTLE_SEC)
-        page_idx += 1
+            next_page()
+            time.sleep(PAGE_SETTLE_SEC)
+            page_idx += 1
+    finally:
+        if preview:
+            close_overlay()
 
 
 if __name__ == "__main__":

--- a/ArenaTracker/overlay.py
+++ b/ArenaTracker/overlay.py
@@ -1,7 +1,8 @@
 import cv2
-from pathlib import Path
-from typing import List, Tuple
-from config import FRAMES_DIR
+from typing import List
+
+
+WINDOW_TITLE = "Arena Scraper Preview (green=card, red=title)"
 
 
 def draw_boxes(frame, tiles, color_card=(0, 255, 0), color_title=(0, 0, 255)):
@@ -24,10 +25,16 @@ def draw_boxes(frame, tiles, color_card=(0, 255, 0), color_title=(0, 0, 255)):
     return canvas
 
 
-def show_and_save(frame, tiles, page_idx: int, window: bool):
+def show_overlay(frame, tiles, window: bool):
+    if not window:
+        return
     annotated = draw_boxes(frame, tiles)
-    FRAMES_DIR.mkdir(parents=True, exist_ok=True)
-    cv2.imwrite(str(FRAMES_DIR / f"page_{page_idx:04d}.png"), annotated)
-    if window:
-        cv2.imshow("Arena Scraper Preview (green=card, red=title)", annotated)
-        cv2.waitKey(1)
+    cv2.imshow(WINDOW_TITLE, annotated)
+    cv2.waitKey(1)
+
+
+def close_overlay():
+    try:
+        cv2.destroyWindow(WINDOW_TITLE)
+    except cv2.error:
+        pass


### PR DESCRIPTION
## Summary
- avoid clicking the center of the screen when focusing the MTGA window
- show the overlay in real time without writing annotated frames to disk
- detect when the 2x6 card grid is obstructed and prompt the user to retry or abort before continuing

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68d000ebacc883329aa44dc743c197df